### PR TITLE
Fix placement of MNAME in SOA record

### DIFF
--- a/bin/xip-pdns
+++ b/bin/xip-pdns
@@ -134,7 +134,7 @@ resolve_v6_subdomain() {
 }
 
 answer_soa_query() {
-  send_answer "SOA" "admin.$XIP_DOMAIN ns-1.$XIP_DOMAIN $XIP_TIMESTAMP $XIP_TTL $XIP_TTL $XIP_TTL $XIP_TTL"
+  send_answer "SOA" "ns-1.$XIP_DOMAIN admin.$XIP_DOMAIN $XIP_TIMESTAMP $XIP_TTL $XIP_TTL $XIP_TTL $XIP_TTL"
 }
 
 answer_ns_query() {


### PR DESCRIPTION
According to RFC 1035 section 3.3.13 the MNAME comes ahead of the RNAME.